### PR TITLE
feat: function to convert Utf8 string to bytes

### DIFF
--- a/src/cjs/browser.cjs
+++ b/src/cjs/browser.cjs
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.compare = exports.fromHex = exports.toHex = exports.toUtf8 = void 0;
+exports.compare = exports.fromHex = exports.fromUtf8 = exports.toHex = exports.toUtf8 = void 0;
 const HEX_STRINGS = "0123456789abcdefABCDEF";
 const HEX_CODES = HEX_STRINGS.split("").map((c) => c.codePointAt(0));
 const HEX_CODEPOINTS = Array(256)
@@ -42,6 +42,10 @@ function _toHexLengthPerf(bytes) {
     }
     return DECODER.decode(hexBytes);
 }
+function fromUtf8(utf8String) {
+    return ENCODER.encode(utf8String);
+}
+exports.fromUtf8 = fromUtf8;
 // Mimics Buffer.from(x, 'hex') logic
 // Stops on first non-hex string and returns
 // https://github.com/nodejs/node/blob/v14.18.1/src/string_bytes.cc#L246-L261

--- a/src/cjs/index.cjs
+++ b/src/cjs/index.cjs
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.compare = exports.fromHex = exports.toHex = exports.toUtf8 = void 0;
+exports.compare = exports.fromUtf8 = exports.fromHex = exports.toHex = exports.toUtf8 = void 0;
 function toUtf8(bytes) {
     return Buffer.from(bytes || []).toString();
 }
@@ -13,6 +13,10 @@ function fromHex(hexString) {
     return Uint8Array.from(Buffer.from(hexString || "", "hex"));
 }
 exports.fromHex = fromHex;
+function fromUtf8(hexString) {
+    return Uint8Array.from(Buffer.from(hexString || ""));
+}
+exports.fromUtf8 = fromUtf8;
 function compare(v1, v2) {
     return Buffer.from(v1).compare(Buffer.from(v2));
 }

--- a/src/cjs/index.cjs
+++ b/src/cjs/index.cjs
@@ -13,8 +13,8 @@ function fromHex(hexString) {
     return Uint8Array.from(Buffer.from(hexString || "", "hex"));
 }
 exports.fromHex = fromHex;
-function fromUtf8(hexString) {
-    return Uint8Array.from(Buffer.from(hexString || ""));
+function fromUtf8(utf8String) {
+    return Uint8Array.from(Buffer.from(utf8String || ""));
 }
 exports.fromUtf8 = fromUtf8;
 function compare(v1, v2) {

--- a/src/cjs/index.d.ts
+++ b/src/cjs/index.d.ts
@@ -1,5 +1,6 @@
 export declare function toUtf8(bytes: Uint8Array): string;
 export declare function toHex(bytes: Uint8Array): string;
 export declare function fromHex(hexString: string): Uint8Array;
+export declare function fromUtf8(hexString: string): Uint8Array;
 export declare type CompareResult = -1 | 0 | 1;
 export declare function compare(v1: Uint8Array, v2: Uint8Array): CompareResult;

--- a/src/cjs/index.d.ts
+++ b/src/cjs/index.d.ts
@@ -1,6 +1,6 @@
 export declare function toUtf8(bytes: Uint8Array): string;
 export declare function toHex(bytes: Uint8Array): string;
 export declare function fromHex(hexString: string): Uint8Array;
-export declare function fromUtf8(hexString: string): Uint8Array;
+export declare function fromUtf8(utf8String: string): Uint8Array;
 export declare type CompareResult = -1 | 0 | 1;
 export declare function compare(v1: Uint8Array, v2: Uint8Array): CompareResult;

--- a/src/mjs/browser.js
+++ b/src/mjs/browser.js
@@ -37,6 +37,9 @@ function _toHexLengthPerf(bytes) {
     }
     return DECODER.decode(hexBytes);
 }
+export function fromUtf8(utf8String) {
+    return ENCODER.encode(utf8String);
+}
 // Mimics Buffer.from(x, 'hex') logic
 // Stops on first non-hex string and returns
 // https://github.com/nodejs/node/blob/v14.18.1/src/string_bytes.cc#L246-L261

--- a/src/mjs/index.js
+++ b/src/mjs/index.js
@@ -7,8 +7,8 @@ export function toHex(bytes) {
 export function fromHex(hexString) {
     return Uint8Array.from(Buffer.from(hexString || "", "hex"));
 }
-export function fromUtf8(hexString) {
-    return Uint8Array.from(Buffer.from(hexString || ""));
+export function fromUtf8(utf8String) {
+    return Uint8Array.from(Buffer.from(utf8String || ""));
 }
 export function compare(v1, v2) {
     return Buffer.from(v1).compare(Buffer.from(v2));

--- a/src/mjs/index.js
+++ b/src/mjs/index.js
@@ -7,6 +7,9 @@ export function toHex(bytes) {
 export function fromHex(hexString) {
     return Uint8Array.from(Buffer.from(hexString || "", "hex"));
 }
+export function fromUtf8(hexString) {
+    return Uint8Array.from(Buffer.from(hexString || ""));
+}
 export function compare(v1, v2) {
     return Buffer.from(v1).compare(Buffer.from(v2));
 }

--- a/ts_src/browser.ts
+++ b/ts_src/browser.ts
@@ -40,6 +40,10 @@ function _toHexLengthPerf(bytes: Uint8Array): string {
   return DECODER.decode(hexBytes);
 }
 
+export function fromUtf8(utf8String: string): Uint8Array {
+  return ENCODER.encode(utf8String);
+}
+
 // Mimics Buffer.from(x, 'hex') logic
 // Stops on first non-hex string and returns
 // https://github.com/nodejs/node/blob/v14.18.1/src/string_bytes.cc#L246-L261

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -10,8 +10,8 @@ export function fromHex(hexString: string): Uint8Array {
   return Uint8Array.from(Buffer.from(hexString || "", "hex"));
 }
 
-export function fromUtf8(hexString: string): Uint8Array {
-  return Uint8Array.from(Buffer.from(hexString || ""));
+export function fromUtf8(utf8String: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(utf8String || ""));
 }
 
 export type CompareResult = -1 | 0 | 1;

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -10,6 +10,10 @@ export function fromHex(hexString: string): Uint8Array {
   return Uint8Array.from(Buffer.from(hexString || "", "hex"));
 }
 
+export function fromUtf8(hexString: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(hexString || ""));
+}
+
 export type CompareResult = -1 | 0 | 1;
 export function compare(v1: Uint8Array, v2: Uint8Array): CompareResult {
   return Buffer.from(v1).compare(Buffer.from(v2)) as CompareResult;

--- a/ts_src/tests.spec.ts
+++ b/ts_src/tests.spec.ts
@@ -42,6 +42,10 @@ describe(`Uint8Array tools`, () => {
           expect(tools.fromHex(bhex)).toEqual(result);
         });
       }
+      it(`should parse hex with fromUtf8`, () => {
+        expect(tools.fromUtf8(utf8)).toEqual(bytes3);
+        expect((tools.fromUtf8 as any)()).toEqual(f([]));
+      });
       it(`should output hex with toHex`, () => {
         expect(tools.toHex(bytes)).toEqual(hex);
         expect(tools.toHex(longBytes)).toEqual(longHex);


### PR DESCRIPTION
New function "fromUtf8" has been added to convert Utf8 string to uint8Array bytes.
The function returns ```Uint8Array.from(Buffer.from(utf8String || ""))```
Some tests are also added to verify code.